### PR TITLE
모임 생성 화면에서 모임 취향 선택을 제외하고 모임명 입력 시 최대 글자수를 제한합니다.

### DIFF
--- a/core/designsystem/src/main/java/com/plottwist/core/designsystem/component/TextField.kt
+++ b/core/designsystem/src/main/java/com/plottwist/core/designsystem/component/TextField.kt
@@ -13,9 +13,11 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.input.InputTransformation
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.clearText
+import androidx.compose.foundation.text.input.maxLength
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -61,6 +63,7 @@ fun TukTextField(
         textStyle = TukPretendardTypography.body16R.copy(
             color = Gray900
         ),
+        inputTransformation = InputTransformation.Companion.maxLength(maxLength),
         decorator = { innerTextField ->
             Column() {
                 Row(

--- a/core/designsystem/src/main/java/com/plottwist/core/designsystem/component/TextField.kt
+++ b/core/designsystem/src/main/java/com/plottwist/core/designsystem/component/TextField.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.plottwist.core.designsystem.R
@@ -47,6 +48,7 @@ fun TukTextField(
     isFocus: Boolean,
     onClear: () -> Unit,
     modifier: Modifier = Modifier,
+    maxLength: Int = 0,
     focusRequester: FocusRequester = remember { FocusRequester() },
     onFocus: (Boolean) -> Unit = {}
 ) {
@@ -60,53 +62,67 @@ fun TukTextField(
             color = Gray900
         ),
         decorator = { innerTextField ->
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(
-                        color = if(isFocus) Gray000 else Gray100,
-                        shape = RoundedCornerShape(15.dp)
-                    ).then(
-                        if(isFocus) Modifier.border(
-                            width = 1.dp,
-                            color = Gray900,
-                            shape = RoundedCornerShape(15.dp)
-                        ) else Modifier
-                    ),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Column(
+            Column() {
+                Row(
                     modifier = Modifier
-                        .weight(1f)
-                        .padding(20.dp)
-                ) {
-                    if (label.isNotBlank()) {
-                        Text(
-                            modifier = Modifier.padding(bottom = 6.dp),
-                            text = label,
-                            style = TukPretendardTypography.body12M,
-                            color = Gray500
+                        .fillMaxWidth()
+                        .background(
+                            color = if (isFocus) Gray000 else Gray100,
+                            shape = RoundedCornerShape(15.dp)
                         )
-                    }
-
-                    Box(
+                        .then(
+                            if (isFocus) Modifier.border(
+                                width = 1.dp,
+                                color = Gray900,
+                                shape = RoundedCornerShape(15.dp)
+                            ) else Modifier
+                        ),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(
                         modifier = Modifier
-                            .fillMaxWidth()
+                            .weight(1f)
+                            .padding(20.dp)
                     ) {
-                        if (state.text.isEmpty()) {
+                        if (label.isNotBlank()) {
                             Text(
-                                text = hint,
-                                color = Gray700,
-                                style = TukPretendardTypography.body16R
+                                modifier = Modifier.padding(bottom = 6.dp),
+                                text = label,
+                                style = TukPretendardTypography.body12M,
+                                color = Gray500
                             )
                         }
-                        innerTextField()
+
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                        ) {
+                            if (state.text.isEmpty()) {
+                                Text(
+                                    text = hint,
+                                    color = Gray700,
+                                    style = TukPretendardTypography.body16R
+                                )
+                            }
+                            innerTextField()
+                        }
+                    }
+                    if (state.text.isNotEmpty()) {
+                        ClearButton(
+                            modifier = Modifier.padding(end = 10.dp),
+                            onClick = onClear
+                        )
                     }
                 }
-                if (state.text.isNotEmpty()) {
-                    ClearButton(
-                        modifier = Modifier.padding(end = 10.dp),
-                        onClick = onClear
+                if (maxLength != 0) {
+                    Text(
+                        modifier = Modifier
+                            .align(Alignment.End)
+                            .padding(top = 10.dp,end = 10.dp),
+                        text = "${state.text.length}/${maxLength}",
+                        style = TukPretendardTypography.body12R,
+                        color = Gray500,
+                        textAlign = TextAlign.End
                     )
                 }
             }

--- a/feature/create_gathering/src/main/java/com/plottwist/create_gathering/CreateGatheringScreen.kt
+++ b/feature/create_gathering/src/main/java/com/plottwist/create_gathering/CreateGatheringScreen.kt
@@ -1,5 +1,6 @@
 package com.plottwist.create_gathering
 
+import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,6 +12,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.plottwist.create_gathering.page.CreateGatheringNameInput
 import com.plottwist.create_gathering.page.CreateGatheringSelectIntervalDays
@@ -28,10 +30,10 @@ fun CreateGatheringScreen(
 ) {
 
     val state by viewModel.container.stateFlow.collectAsState()
-
+    val context = LocalContext.current
     val pagerState = rememberPagerState(
         initialPage = state.currentPage,
-        pageCount = { 3 }
+        pageCount = { 2 }
     )
 
     BackHandler {
@@ -50,6 +52,11 @@ fun CreateGatheringScreen(
         viewModel.container.sideEffectFlow.collect { effect ->
             when (effect) {
                 CreateGatheringSideEffect.NavigateToHomeScreen -> {
+                    Toast.makeText(
+                        context,
+                        "모임이 생성되었어요!",
+                        Toast.LENGTH_SHORT
+                    ).show()
                     navigateToHomeScreen()
                 }
 
@@ -96,17 +103,8 @@ fun CreateGatheringScreen(
                         viewModel.onAction(CreateGatheringAction.UpdateIntervalDays(it))
                     },
                     onNext = {
-                        viewModel.onAction(CreateGatheringAction.ClickNext)
+                        viewModel.onAction(CreateGatheringAction.SubmitGathering)
                     }
-                )
-
-                2 -> CreateGatheringSelectTags(
-                    categories = state.tagCategories,
-                    selectedTags = state.tags,
-                    onToggle = { viewModel.onAction(CreateGatheringAction.ToggleTag(it)) },
-                    onClickPrev = { viewModel.onAction(CreateGatheringAction.ClickPrev) },
-                    onClickNext = { viewModel.onAction(CreateGatheringAction.SubmitGathering) },
-                    onClickSkip = { viewModel.onAction(CreateGatheringAction.ClickSkip) }
                 )
             }
         }

--- a/feature/create_gathering/src/main/java/com/plottwist/create_gathering/CreateGatheringViewModel.kt
+++ b/feature/create_gathering/src/main/java/com/plottwist/create_gathering/CreateGatheringViewModel.kt
@@ -42,8 +42,6 @@ class CreateGatheringViewModel @Inject constructor(
             is CreateGatheringAction.ClickNext -> {
                 if (state.currentPage < MAX_PAGE) {
                     reduce { state.copy(currentPage = state.currentPage + 1) }
-                } else {
-                    postSideEffect(CreateGatheringSideEffect.NavigateToHomeScreen)
                 }
             }
 

--- a/feature/create_gathering/src/main/java/com/plottwist/create_gathering/page/IntervalDaysPage.kt
+++ b/feature/create_gathering/src/main/java/com/plottwist/create_gathering/page/IntervalDaysPage.kt
@@ -43,7 +43,7 @@ fun CreateGatheringSelectIntervalDays(
 
                 TukSolidButton(
                     modifier = Modifier.weight(1f),
-                    text = "다음",
+                    text = "생성하기",
                     buttonType = TukSolidButtonType.from(selectedOption != 0),
                     onClick = onNext
                 )

--- a/feature/create_gathering/src/main/java/com/plottwist/create_gathering/page/NameInputPage.kt
+++ b/feature/create_gathering/src/main/java/com/plottwist/create_gathering/page/NameInputPage.kt
@@ -50,7 +50,8 @@ fun CreateGatheringNameInput(
                 onFocus = {
                     isFocused = it
                 },
-                onClear = onClear
+                onClear = onClear,
+                maxLength = 10
             )
         }
     }


### PR DESCRIPTION
## 작업
- 모임 생성 화면에서 취향 선택 제외
- 모임명 입력 글자수 제한 처리


## 스크린샷 or 영상


https://github.com/user-attachments/assets/504d8e80-72e0-4a91-b90b-70557282afda

