### PR TITLE
이름 설정 화면에서 이름을 변경할 수 있습니다.

### DIFF
--- a/core/data/src/main/java/com/plottwist/core/data/auth/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/plottwist/core/data/auth/repository/AuthRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.plottwist.core.domain.auth.repository.AuthRepository
 import com.plottwist.core.domain.push.repository.PushRepository
 import com.plottwist.core.network.model.auth.DeviceInfo
 import com.plottwist.core.network.model.auth.GoogleLoginRequest
+import com.plottwist.core.network.model.onboarding.MemberNameRequest
 import com.plottwist.core.network.service.AuthApiService
 import com.plottwist.core.network.service.TukApiService
 import com.plottwist.core.preference.datasource.AuthDataSource
@@ -82,6 +83,22 @@ class AuthRepositoryImpl @Inject constructor(
             if (response.success) {
                 authDataSource.clear().collect()
                 Result.success(true)
+            } else {
+                Result.failure(Exception("Fail Delete member"))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun updateMemberName(name: String): Result<Unit> {
+        return try {
+            val response = tukApiService.updateMemberName(
+                MemberNameRequest(name)
+            )
+
+            if (response.success) {
+                Result.success(Unit)
             } else {
                 Result.failure(Exception("Fail Delete member"))
             }

--- a/core/data/src/main/java/com/plottwist/core/data/onboarding/OnboardingRepositoryImpl.kt
+++ b/core/data/src/main/java/com/plottwist/core/data/onboarding/OnboardingRepositoryImpl.kt
@@ -20,7 +20,7 @@ class OnboardingRepositoryImpl @Inject constructor(
             val  result = onboardingService.updateOnboardingInfo(UpdateOnboardingInfoRequest(name))
 
             if (result.success) {
-                authDataSource.setOnboardingCompleted(true).collect()
+                authDataSource.setMemberName(name).collect()
                 return Result.success(Unit)
             }
 
@@ -35,6 +35,7 @@ class OnboardingRepositoryImpl @Inject constructor(
             val result = onboardingService.getMemberInfo()
 
             if (result.success) {
+                authDataSource.setMemberName(result.data.name).collect()
                 return Result.success(result.data.toDomainModel())
             }
 

--- a/core/domain/src/main/java/com/plottwist/core/domain/auth/repository/AuthRepository.kt
+++ b/core/domain/src/main/java/com/plottwist/core/domain/auth/repository/AuthRepository.kt
@@ -9,4 +9,6 @@ interface AuthRepository {
     fun getAccessToken() : Flow<String?>
     suspend fun deleteAccount(): Result<Boolean>
     suspend fun updateMemberName(name: String): Result<Unit>
+    fun getMemberName(): Flow<String?>
+    fun setMemberName(name: String): Flow<Unit>
 }

--- a/core/domain/src/main/java/com/plottwist/core/domain/auth/repository/AuthRepository.kt
+++ b/core/domain/src/main/java/com/plottwist/core/domain/auth/repository/AuthRepository.kt
@@ -8,4 +8,5 @@ interface AuthRepository {
     fun logout(): Flow<Unit>
     fun getAccessToken() : Flow<String?>
     suspend fun deleteAccount(): Result<Boolean>
+    suspend fun updateMemberName(name: String): Result<Unit>
 }

--- a/core/domain/src/main/java/com/plottwist/core/domain/auth/usecase/GetMemberNameUseCase.kt
+++ b/core/domain/src/main/java/com/plottwist/core/domain/auth/usecase/GetMemberNameUseCase.kt
@@ -1,0 +1,13 @@
+package com.plottwist.core.domain.auth.usecase
+
+import com.plottwist.core.domain.auth.repository.AuthRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetMemberNameUseCase @Inject constructor(
+    private val authRepository: AuthRepository
+) {
+    operator fun invoke(): Flow<String?> {
+        return authRepository.getMemberName()
+    }
+}

--- a/core/domain/src/main/java/com/plottwist/core/domain/auth/usecase/UpdateMemberNameUseCase.kt
+++ b/core/domain/src/main/java/com/plottwist/core/domain/auth/usecase/UpdateMemberNameUseCase.kt
@@ -1,0 +1,12 @@
+package com.plottwist.core.domain.auth.usecase
+
+import com.plottwist.core.domain.auth.repository.AuthRepository
+import javax.inject.Inject
+
+class UpdateMemberNameUseCase @Inject constructor(
+    private val authRepository: AuthRepository
+) {
+    suspend operator fun invoke(name: String): Result<Unit> {
+        return authRepository.updateMemberName(name)
+    }
+}

--- a/core/network/src/main/java/com/plottwist/core/network/model/onboarding/MemberNameRequest.kt
+++ b/core/network/src/main/java/com/plottwist/core/network/model/onboarding/MemberNameRequest.kt
@@ -1,0 +1,8 @@
+package com.plottwist.core.network.model.onboarding
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MemberNameRequest(
+    val name: String
+)

--- a/core/network/src/main/java/com/plottwist/core/network/service/TukApiService.kt
+++ b/core/network/src/main/java/com/plottwist/core/network/service/TukApiService.kt
@@ -13,6 +13,8 @@ import com.plottwist.core.network.model.gathering.GetPurposesResponse
 import com.plottwist.core.network.model.gathering.GetTagsResponse
 import com.plottwist.core.network.model.gathering.UpdateGatheringRequest
 import com.plottwist.core.network.model.gathering.UpdateGatheringResponse
+import com.plottwist.core.network.model.onboarding.MemberInfoResponse
+import com.plottwist.core.network.model.onboarding.MemberNameRequest
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
@@ -64,4 +66,9 @@ interface TukApiService {
 
     @DELETE("/api/v1/members")
     suspend fun deleteMember(): DeleteMemberResponse
+
+    @PATCH("/api/v1/members")
+    suspend fun updateMemberName(
+        @Body memberNameRequest : MemberNameRequest
+    ): MemberInfoResponse
 }

--- a/core/preference/src/main/java/com/plottwist/core/preference/datasource/AuthDataSource.kt
+++ b/core/preference/src/main/java/com/plottwist/core/preference/datasource/AuthDataSource.kt
@@ -6,11 +6,11 @@ interface AuthDataSource {
 
     fun getAccessToken(): Flow<String?>
     fun getRefreshToken(): Flow<String?>
-    fun getOnboardingCompleted(): Flow<Boolean?>
+    fun getMemberName(): Flow<String?>
 
     fun setAccessToken(accessToken: String): Flow<Unit>
     fun setRefreshToken(refreshToken: String): Flow<Unit>
-    fun setOnboardingCompleted(completed: Boolean): Flow<Unit>
+    fun setMemberName(name: String): Flow<Unit>
 
     fun clear(): Flow<Unit>
 }

--- a/core/preference/src/main/java/com/plottwist/core/preference/datasource/AuthDataSourceImpl.kt
+++ b/core/preference/src/main/java/com/plottwist/core/preference/datasource/AuthDataSourceImpl.kt
@@ -2,7 +2,6 @@ package com.plottwist.core.preference.datasource
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.Flow
@@ -24,9 +23,9 @@ class AuthDataSourceImpl @Inject constructor(
             preferences[REFRESH_TOKEN]
         }
 
-    override fun getOnboardingCompleted(): Flow<Boolean?> =
+    override fun getMemberName(): Flow<String?> =
         dataStore.data.map { preferences ->
-            preferences[ONBOARDING_COMPLETED]
+            preferences[MEMBER_NAME]
         }
 
 
@@ -42,9 +41,9 @@ class AuthDataSourceImpl @Inject constructor(
         }
     }
 
-    override fun setOnboardingCompleted(completed: Boolean): Flow<Unit> = flow {
+    override fun setMemberName(name: String): Flow<Unit> = flow {
         dataStore.edit { preferences ->
-            preferences[ONBOARDING_COMPLETED] = completed
+            preferences[MEMBER_NAME] = name
         }
     }
 
@@ -52,6 +51,7 @@ class AuthDataSourceImpl @Inject constructor(
         dataStore.edit { preferences ->
             preferences[ACCESS_TOKEN] = ""
             preferences[REFRESH_TOKEN] = ""
+            preferences[MEMBER_NAME] = ""
         }
     }
 
@@ -59,6 +59,6 @@ class AuthDataSourceImpl @Inject constructor(
         const val TOKEN_PREFERENCES_NAME = "token_preferences"
         private val ACCESS_TOKEN = stringPreferencesKey("access_token")
         private val REFRESH_TOKEN = stringPreferencesKey("refresh_token")
-        private val ONBOARDING_COMPLETED = booleanPreferencesKey("onboarding_completed")
+        private val MEMBER_NAME = stringPreferencesKey("member_name")
     }
 }

--- a/core/ui-navigation/src/main/java/com/plottwist/core/ui/navigation/Route.kt
+++ b/core/ui-navigation/src/main/java/com/plottwist/core/ui/navigation/Route.kt
@@ -83,4 +83,7 @@ sealed interface Route {
         val gatheringId: Long,
         val selectedIntervalDays : Long
     ): Route
+
+    @Serializable
+    data object EditName : Route
 }

--- a/feature/main/src/main/java/com/plottwist/feature/main/ui/component/TukNavHost.kt
+++ b/feature/main/src/main/java/com/plottwist/feature/main/ui/component/TukNavHost.kt
@@ -17,7 +17,9 @@ import com.plottwist.feature.home.navigation.homeNavGraph
 import com.plottwist.feature.home.navigation.navigateToHome
 import com.plottwist.feature.login.navigation.loginNavGraph
 import com.plottwist.feature.login.navigation.navigateToLogin
+import com.plottwist.feature.mypage.navigation.editNameNavGraph
 import com.plottwist.feature.mypage.navigation.myPageNavGraph
+import com.plottwist.feature.mypage.navigation.navigateToEditName
 import com.plottwist.feature.mypage.navigation.navigateToMyPage
 import com.plottwist.feature.mypage.navigation.navigateToNotificationSetting
 import com.plottwist.feature.mypage.navigation.navigateToPolicyWebView
@@ -115,6 +117,9 @@ fun TukNavHost(
                     "개인정보 처리방침",
                     "https://www.tuk.kr/privacy-policy"
                 )
+            },
+            navigateToEditName = {
+                navController.navigateToEditName()
             }
         )
         notificationSettingNavGraph(
@@ -250,6 +255,12 @@ fun TukNavHost(
                         }
                     }
                 )
+            }
+        )
+
+        editNameNavGraph(
+            onBack = {
+                navController.popBackStack()
             }
         )
     }

--- a/feature/mypage/src/main/java/com/plottwist/feature/mypage/MyPageScreen.kt
+++ b/feature/mypage/src/main/java/com/plottwist/feature/mypage/MyPageScreen.kt
@@ -44,7 +44,8 @@ fun MyPageScreen(
     navigateToHome: () -> Unit,
     navigateToNotificationSetting: () -> Unit,
     navigateToTerms: () -> Unit,
-    navigateToPrivacyPolicy: () -> Unit
+    navigateToPrivacyPolicy: () -> Unit,
+    navigateToEditName: () -> Unit
 ) {
 
     val state by viewModel.container.stateFlow.collectAsState()
@@ -55,7 +56,7 @@ fun MyPageScreen(
     viewModel.collectSideEffect { sideEffect ->
         when (sideEffect) {
             MyPageSideEffect.NavigateToEditName -> {
-
+                navigateToEditName()
             }
 
             MyPageSideEffect.NavigateToNotificationSetting -> {

--- a/feature/mypage/src/main/java/com/plottwist/feature/mypage/edit_name/EditNameContract.kt
+++ b/feature/mypage/src/main/java/com/plottwist/feature/mypage/edit_name/EditNameContract.kt
@@ -1,0 +1,18 @@
+package com.plottwist.feature.mypage.edit_name
+
+data class EditNameState(
+    val name: String = "",
+    val isLoading: Boolean = false
+)
+
+sealed class EditNameAction {
+    data object ClickBack : EditNameAction()
+    data class OnNameChanged(val name: String) : EditNameAction()
+    data object ClickSave : EditNameAction()
+}
+
+sealed class EditNameSideEffect {
+    data object NavigateBack : EditNameSideEffect()
+    data object SaveSuccess : EditNameSideEffect()
+    data class ShowToast(val message: String) : EditNameSideEffect()
+}

--- a/feature/mypage/src/main/java/com/plottwist/feature/mypage/edit_name/EditNameContract.kt
+++ b/feature/mypage/src/main/java/com/plottwist/feature/mypage/edit_name/EditNameContract.kt
@@ -1,13 +1,15 @@
 package com.plottwist.feature.mypage.edit_name
 
+import androidx.compose.foundation.text.input.TextFieldState
+
 data class EditNameState(
-    val name: String = "",
+    val name: TextFieldState = TextFieldState(),
+    val originalName: String = "",
     val isLoading: Boolean = false
 )
 
 sealed class EditNameAction {
     data object ClickBack : EditNameAction()
-    data class OnNameChanged(val name: String) : EditNameAction()
     data object ClickSave : EditNameAction()
 }
 

--- a/feature/mypage/src/main/java/com/plottwist/feature/mypage/edit_name/EditNameScreen.kt
+++ b/feature/mypage/src/main/java/com/plottwist/feature/mypage/edit_name/EditNameScreen.kt
@@ -1,5 +1,6 @@
 package com.plottwist.feature.mypage.edit_name
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -12,6 +13,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -33,6 +35,7 @@ fun EditNameScreen(
     viewModel: EditNameViewModel = hiltViewModel(),
 ) {
     val state by viewModel.collectAsState()
+    val context = LocalContext.current
 
     viewModel.collectSideEffect {
         when (it) {
@@ -40,7 +43,12 @@ fun EditNameScreen(
                 onBack()
             }
             EditNameSideEffect.SaveSuccess -> {
-
+                Toast.makeText(
+                    context,
+                    "이름이 변경되었어요!",
+                    Toast.LENGTH_SHORT
+                ).show()
+                onBack()
             }
 
             is EditNameSideEffect.ShowToast -> {

--- a/feature/mypage/src/main/java/com/plottwist/feature/mypage/edit_name/EditNameScreen.kt
+++ b/feature/mypage/src/main/java/com/plottwist/feature/mypage/edit_name/EditNameScreen.kt
@@ -1,0 +1,85 @@
+package com.plottwist.feature.mypage.edit_name
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.plottwist.core.designsystem.component.TukTopAppBar
+import com.plottwist.core.designsystem.component.TukTopAppBarType
+import org.orbitmvi.orbit.compose.collectAsState
+import org.orbitmvi.orbit.compose.collectSideEffect
+
+@Composable
+fun EditNameScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: EditNameViewModel = hiltViewModel(),
+) {
+    val state by viewModel.collectAsState()
+
+    viewModel.collectSideEffect {
+        when (it) {
+            EditNameSideEffect.NavigateBack -> {
+                onBack()
+            }
+            EditNameSideEffect.SaveSuccess -> {
+
+            }
+
+            is EditNameSideEffect.ShowToast -> {
+
+            }
+        }
+    }
+
+    EditNameScreen(
+        modifier = modifier,
+        name = state.name,
+        onBackClick = { viewModel.handleAction(EditNameAction.ClickBack) },
+        onNameChanged = { viewModel.handleAction(EditNameAction.OnNameChanged(it)) },
+        onSaveClick = { viewModel.handleAction(EditNameAction.ClickSave) }
+    )
+}
+
+@Composable
+private fun EditNameScreen(
+    name: String,
+    onBackClick: () -> Unit,
+    onNameChanged: (String) -> Unit,
+    onSaveClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxSize()
+    ) {
+        EditNameAppBar(onBackClick = onBackClick)
+        // TODO: Add content for editing name (e.g., TextField)
+    }
+}
+
+@Composable
+fun EditNameAppBar(
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TukTopAppBar(
+        modifier = modifier,
+        type = TukTopAppBarType.DEPTH,
+        title = "이름 변경",
+        onBack = onBackClick
+    )
+}
+
+@Preview
+@Composable
+private fun EditNameScreenPreview() {
+    EditNameScreen(
+        name = "테스트 이름",
+        onBackClick = {},
+        onNameChanged = {},
+        onSaveClick = {}
+    )
+}

--- a/feature/mypage/src/main/java/com/plottwist/feature/mypage/edit_name/EditNameScreen.kt
+++ b/feature/mypage/src/main/java/com/plottwist/feature/mypage/edit_name/EditNameScreen.kt
@@ -2,13 +2,27 @@ package com.plottwist.feature.mypage.edit_name
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.clearText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.plottwist.core.designsystem.R
+import com.plottwist.core.designsystem.component.TukSolidButton
+import com.plottwist.core.designsystem.component.TukSolidButtonType
+import com.plottwist.core.designsystem.component.TukTextField
 import com.plottwist.core.designsystem.component.TukTopAppBar
 import com.plottwist.core.designsystem.component.TukTopAppBarType
+import com.plottwist.core.ui.component.TukScaffold
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
 
@@ -38,25 +52,51 @@ fun EditNameScreen(
     EditNameScreen(
         modifier = modifier,
         name = state.name,
+        originalName = state.originalName,
         onBackClick = { viewModel.handleAction(EditNameAction.ClickBack) },
-        onNameChanged = { viewModel.handleAction(EditNameAction.OnNameChanged(it)) },
         onSaveClick = { viewModel.handleAction(EditNameAction.ClickSave) }
     )
 }
 
 @Composable
 private fun EditNameScreen(
-    name: String,
+    name: TextFieldState,
+    originalName: String,
     onBackClick: () -> Unit,
-    onNameChanged: (String) -> Unit,
     onSaveClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier.fillMaxSize()
+    var isNameFocused by remember { mutableStateOf(false) }
+
+    TukScaffold (
+        modifier = modifier,
+        topBar = {
+            EditNameAppBar(onBackClick = onBackClick)
+        },
+        bottomBar = {
+            EditNameSubmitButton(
+                isEnabled = name.text.toString() != originalName && name.text.isNotBlank(),
+                onClick = onSaveClick
+            )
+        },
+        title = stringResource(R.string.onboarding_name_title),
+        description = stringResource(R.string.onboarding_name_description),
     ) {
-        EditNameAppBar(onBackClick = onBackClick)
-        // TODO: Add content for editing name (e.g., TextField)
+        item {
+            TukTextField(
+                state = name,
+                label = stringResource(R.string.onboarding_name_text_field_label),
+                hint = stringResource(R.string.onboarding_name_text_field_hint),
+                isFocus = isNameFocused,
+                maxLength = 10,
+                onFocus = {
+                    isNameFocused = it
+                },
+                onClear = {
+                    name.clearText()
+                }
+            )
+        }
     }
 }
 
@@ -68,8 +108,22 @@ fun EditNameAppBar(
     TukTopAppBar(
         modifier = modifier,
         type = TukTopAppBarType.DEPTH,
-        title = "이름 변경",
+        title = "이름 설정",
         onBack = onBackClick
+    )
+}
+
+@Composable
+fun EditNameSubmitButton(
+    isEnabled: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    TukSolidButton(
+        modifier = modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 16.dp),
+        text = "저장하기",
+        onClick = onClick,
+        buttonType = TukSolidButtonType.from(isEnabled)
     )
 }
 
@@ -77,9 +131,9 @@ fun EditNameAppBar(
 @Composable
 private fun EditNameScreenPreview() {
     EditNameScreen(
-        name = "테스트 이름",
+        name = TextFieldState(),
+        originalName = "",
         onBackClick = {},
-        onNameChanged = {},
         onSaveClick = {}
     )
 }

--- a/feature/mypage/src/main/java/com/plottwist/feature/mypage/edit_name/EditNameViewModel.kt
+++ b/feature/mypage/src/main/java/com/plottwist/feature/mypage/edit_name/EditNameViewModel.kt
@@ -1,0 +1,41 @@
+package com.plottwist.feature.mypage.edit_name
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.viewmodel.container
+import javax.inject.Inject
+
+@HiltViewModel
+class EditNameViewModel @Inject constructor() : ContainerHost<EditNameState, EditNameSideEffect>, ViewModel() {
+
+    override val container = container<EditNameState, EditNameSideEffect>(EditNameState())
+
+    fun handleAction(action: EditNameAction) {
+        when (action) {
+            EditNameAction.ClickBack -> {
+                navigateBack()
+            }
+            is EditNameAction.OnNameChanged -> {
+                onNameChanged(action.name)
+            }
+            EditNameAction.ClickSave -> {
+                saveName()
+            }
+        }
+    }
+
+    private fun navigateBack() = intent {
+        postSideEffect(EditNameSideEffect.NavigateBack)
+    }
+
+    private fun onNameChanged(name: String) = intent {
+        reduce { state.copy(name = name) }
+    }
+
+    private fun saveName() = intent {
+        // TODO: Implement actual save logic
+        postSideEffect(EditNameSideEffect.SaveSuccess)
+        postSideEffect(EditNameSideEffect.ShowToast("이름이 저장되었습니다."))
+    }
+}

--- a/feature/mypage/src/main/java/com/plottwist/feature/mypage/edit_name/EditNameViewModel.kt
+++ b/feature/mypage/src/main/java/com/plottwist/feature/mypage/edit_name/EditNameViewModel.kt
@@ -1,23 +1,38 @@
 package com.plottwist.feature.mypage.edit_name
 
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.lifecycle.ViewModel
+import com.plottwist.core.domain.onboarding.usecase.GetMemberInfoUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.viewmodel.container
 import javax.inject.Inject
 
 @HiltViewModel
-class EditNameViewModel @Inject constructor() : ContainerHost<EditNameState, EditNameSideEffect>, ViewModel() {
+class EditNameViewModel @Inject constructor(
+    private val getMemberInfoUseCase: GetMemberInfoUseCase
+) : ContainerHost<EditNameState, EditNameSideEffect>, ViewModel() {
+    override val container = container<EditNameState, EditNameSideEffect>(EditNameState()) {
+        getMemberInfo()
+    }
 
-    override val container = container<EditNameState, EditNameSideEffect>(EditNameState())
+    private fun getMemberInfo() = intent {
+        getMemberInfoUseCase().onSuccess { result ->
+            reduce {
+                state.copy(
+                    name = TextFieldState(result.name),
+                    originalName = result.name
+                )
+            }
+        }.onFailure {
+
+        }
+    }
 
     fun handleAction(action: EditNameAction) {
         when (action) {
             EditNameAction.ClickBack -> {
                 navigateBack()
-            }
-            is EditNameAction.OnNameChanged -> {
-                onNameChanged(action.name)
             }
             EditNameAction.ClickSave -> {
                 saveName()
@@ -29,9 +44,6 @@ class EditNameViewModel @Inject constructor() : ContainerHost<EditNameState, Edi
         postSideEffect(EditNameSideEffect.NavigateBack)
     }
 
-    private fun onNameChanged(name: String) = intent {
-        reduce { state.copy(name = name) }
-    }
 
     private fun saveName() = intent {
         // TODO: Implement actual save logic

--- a/feature/mypage/src/main/java/com/plottwist/feature/mypage/edit_name/EditNameViewModel.kt
+++ b/feature/mypage/src/main/java/com/plottwist/feature/mypage/edit_name/EditNameViewModel.kt
@@ -2,6 +2,7 @@ package com.plottwist.feature.mypage.edit_name
 
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.lifecycle.ViewModel
+import com.plottwist.core.domain.auth.usecase.UpdateMemberNameUseCase
 import com.plottwist.core.domain.onboarding.usecase.GetMemberInfoUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.orbitmvi.orbit.ContainerHost
@@ -10,7 +11,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class EditNameViewModel @Inject constructor(
-    private val getMemberInfoUseCase: GetMemberInfoUseCase
+    private val getMemberInfoUseCase: GetMemberInfoUseCase,
+    private val updateMemberNameUseCase : UpdateMemberNameUseCase
 ) : ContainerHost<EditNameState, EditNameSideEffect>, ViewModel() {
     override val container = container<EditNameState, EditNameSideEffect>(EditNameState()) {
         getMemberInfo()
@@ -46,8 +48,11 @@ class EditNameViewModel @Inject constructor(
 
 
     private fun saveName() = intent {
-        // TODO: Implement actual save logic
-        postSideEffect(EditNameSideEffect.SaveSuccess)
-        postSideEffect(EditNameSideEffect.ShowToast("이름이 저장되었습니다."))
+        updateMemberNameUseCase(state.name.text.toString())
+            .onSuccess {
+                postSideEffect(EditNameSideEffect.SaveSuccess)
+            }.onFailure {
+
+            }
     }
 }

--- a/feature/mypage/src/main/java/com/plottwist/feature/mypage/navigation/EditNameNavigation.kt
+++ b/feature/mypage/src/main/java/com/plottwist/feature/mypage/navigation/EditNameNavigation.kt
@@ -1,0 +1,23 @@
+package com.plottwist.feature.mypage.navigation
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import com.plottwist.core.ui.navigation.Route
+import com.plottwist.feature.mypage.edit_name.EditNameScreen
+import com.plottwist.feature.mypage.notification.NotificationSettingScreen
+
+fun NavController.navigateToEditName(
+    navOptions: NavOptions? = null
+) {
+    this.navigate(route = Route.EditName, navOptions = navOptions)
+}
+
+fun NavGraphBuilder.editNameNavGraph(
+    onBack: () -> Unit
+) {
+    composable<Route.EditName> {
+        EditNameScreen(onBack = onBack)
+    }
+}

--- a/feature/mypage/src/main/java/com/plottwist/feature/mypage/navigation/MyPageNavigation.kt
+++ b/feature/mypage/src/main/java/com/plottwist/feature/mypage/navigation/MyPageNavigation.kt
@@ -33,14 +33,17 @@ fun NavGraphBuilder.myPageNavGraph(
     navigateToHome: () -> Unit,
     navigateToNotificationSetting: ()->Unit,
     navigateToTerms: () -> Unit,
-    navigateToPrivacyPolicy: () -> Unit
+    navigateToPrivacyPolicy: () -> Unit,
+    navigateToEditName: () -> Unit
 ) {
     composable<Route.MyPage> {
         MyPageScreen(onBackClick = onBack,
             navigateToHome = navigateToHome,
             navigateToNotificationSetting = navigateToNotificationSetting,
             navigateToTerms = navigateToTerms,
-            navigateToPrivacyPolicy = navigateToPrivacyPolicy)
+            navigateToPrivacyPolicy = navigateToPrivacyPolicy,
+            navigateToEditName = navigateToEditName
+        )
     }
 }
 

--- a/feature/onboarding/src/main/java/com/plottwist/feature/onboarding/OnboardingNameScreen.kt
+++ b/feature/onboarding/src/main/java/com/plottwist/feature/onboarding/OnboardingNameScreen.kt
@@ -87,6 +87,7 @@ private fun OnboardingNameScreen(
                 label = stringResource(R.string.onboarding_name_text_field_label),
                 hint = stringResource(R.string.onboarding_name_text_field_hint),
                 isFocus = isNameFocused,
+                maxLength = 10,
                 onFocus = {
                     isNameFocused = it
                 },


### PR DESCRIPTION
## 작업
- 이름 변경 화면 추가 및 API 연동
- 이름 로컬에 저장 처리

## 참고사항
- 앱 전역에서 쓰이는 유저 이름을 로컬에 저장하게 처리하였습니다.

## 스크린샷 or 영상


https://github.com/user-attachments/assets/18fdea84-00f2-4640-842d-5d16f76a6358

