### PR TITLE
로그아웃, 탈퇴 시 디바이스 토큰을 초기화 처리합니다.

### DIFF
--- a/core/data/src/main/java/com/plottwist/core/data/auth/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/plottwist/core/data/auth/repository/AuthRepositoryImpl.kt
@@ -5,10 +5,12 @@ import com.plottwist.core.domain.auth.repository.AuthRepository
 import com.plottwist.core.domain.onboarding.OnboardingRepository
 import com.plottwist.core.domain.push.repository.PushRepository
 import com.plottwist.core.network.model.auth.DeviceInfo
+import com.plottwist.core.network.model.auth.DeviceInfoRequest
 import com.plottwist.core.network.model.auth.GoogleLoginRequest
 import com.plottwist.core.network.model.auth.TokenRequest
 import com.plottwist.core.network.model.onboarding.MemberNameRequest
 import com.plottwist.core.network.service.AuthApiService
+import com.plottwist.core.network.service.OnboardingService
 import com.plottwist.core.network.service.TukApiService
 import com.plottwist.core.preference.datasource.AuthDataSource
 import kotlinx.coroutines.flow.Flow
@@ -24,7 +26,8 @@ class AuthRepositoryImpl @Inject constructor(
     private val deviceInfoProvider: DeviceInfoProvider,
     private val pushRepository: PushRepository,
     private val tukApiService: TukApiService,
-    private val onboardingRepository: OnboardingRepository
+    private val onboardingRepository: OnboardingRepository,
+    private val onboardingService: OnboardingService
 ) : AuthRepository {
 
     override suspend fun googleLogin(accountId: String): Result<Boolean> {
@@ -145,6 +148,29 @@ class AuthRepositoryImpl @Inject constructor(
             }
         } catch (e: Exception) {
             return Result.failure(e)
+        }
+    }
+
+     override suspend fun resetServerFcmToken() : Result<Unit> {
+        return try {
+            val deviceInfo =
+                DeviceInfoRequest(
+                    DeviceInfo(
+                        deviceId = deviceInfoProvider.getDeviceSSAID(),
+                        deviceType = deviceInfoProvider.getDeviceType(),
+                        appVersion = deviceInfoProvider.getAppVersion(),
+                        osVersion = deviceInfoProvider.getOsVersion(),
+                        deviceToken = "EXPIRED_TOKEN"
+                    )
+                )
+
+
+            val result = onboardingService.updateDeviceToken(deviceInfo)
+
+            return if(result.success) Result.success(Unit)
+            else Result.failure(Exception("Fail Update FCM Token"))
+        } catch (e: Exception){
+            Result.failure(e)
         }
     }
 }

--- a/core/domain/src/main/java/com/plottwist/core/domain/auth/repository/AuthRepository.kt
+++ b/core/domain/src/main/java/com/plottwist/core/domain/auth/repository/AuthRepository.kt
@@ -12,4 +12,5 @@ interface AuthRepository {
     fun getMemberName(): Flow<String?>
     fun setMemberName(name: String): Flow<Unit>
     suspend fun reissueTokens(): Result<Unit>
+    suspend fun resetServerFcmToken() : Result<Unit>
 }

--- a/core/domain/src/main/java/com/plottwist/core/domain/auth/usecase/LogoutUseCase.kt
+++ b/core/domain/src/main/java/com/plottwist/core/domain/auth/usecase/LogoutUseCase.kt
@@ -9,6 +9,10 @@ class LogoutUseCase @Inject constructor(
 ) {
 
     suspend fun logoutWithGoogle() {
-        loginRepository.logout().collect()
+        loginRepository.resetServerFcmToken().onSuccess {
+            loginRepository.logout().collect()
+        }.onFailure {
+            loginRepository.logout().collect()
+        }
     }
 }


### PR DESCRIPTION
## 작업
- 로그아웃, 탈퇴 시 디바이스 토큰 초기화 처리

## 참고사항
- 로그아웃, 탈퇴 시 푸시 알림을 받을 수 없도록 서버에 토큰 초기화를 하도록 합니다. (EXPIRED_TOKEN 값 사용)


