### PR TITLE
초대장 생성 시 모임 선택 화면에서 미선택이어도 다음으로 이동할 수 있습니다.

### DIFF
--- a/feature/home/src/main/java/com/plottwist/feature/home/HomeContract.kt
+++ b/feature/home/src/main/java/com/plottwist/feature/home/HomeContract.kt
@@ -16,7 +16,9 @@ data class HomeState(
     val whenLabel: String = "",
     val whereLabel: String = "",
     val whatLabel: String = "",
-    val proposalTags: UiState<ProposalTags> = UiState.Loading
+    val proposalTags: UiState<ProposalTags> = UiState.Loading,
+    val isRandomPlaying: Boolean = true,
+    val currentIndex : Int = 0
 )
 
 sealed class HomeAction {
@@ -29,6 +31,8 @@ sealed class HomeAction {
     data class ClickPropose(val index : Int): HomeAction()
     data object ClickProposals: HomeAction()
     data object OnPermissionGranted: HomeAction()
+    data object ClickPlay: HomeAction()
+    data object ClickStop: HomeAction()
 }
 
 sealed class HomeSideEffect {

--- a/feature/home/src/main/java/com/plottwist/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/plottwist/feature/home/HomeScreen.kt
@@ -97,7 +97,6 @@ fun HomeScreen(
     var homeBottomSheetAction: HomeBottomSheetAction by remember {
         mutableStateOf(HomeBottomSheetAction.IDLE)
     }
-    var hasBottomSheetShook by remember { mutableStateOf(false) }
     var bottomSheetState by remember { mutableStateOf<HomeBottomSheetState>(HomeBottomSheetState.COLLAPSED) }
 
     BackHandler(bottomSheetState == HomeBottomSheetState.EXPANDED) {
@@ -109,10 +108,6 @@ fun HomeScreen(
         homeBottomSheetAction = HomeBottomSheetAction.IDLE
     }
 
-    LaunchedEffect(Unit) {
-        delay(800)
-        hasBottomSheetShook = true
-    }
 
     viewModel.collectSideEffect { sideEffect ->
         when (sideEffect) {
@@ -170,6 +165,8 @@ fun HomeScreen(
         loginState = state.loginState,
         gatherings = state.gatherings,
         homeBottomSheetAction = homeBottomSheetAction,
+        isPlayed = state.isRandomPlaying,
+        selectedCurrentIndex = state.currentIndex,
         onMyPageClick = {
             viewModel.handleAction(HomeAction.ClickMyPage)
         },
@@ -196,7 +193,13 @@ fun HomeScreen(
         },
         onProposalsClick = {
             viewModel.handleAction(HomeAction.ClickProposals)
-        }
+        },
+        onStopClick = {
+            viewModel.handleAction(HomeAction.ClickStop)
+        },
+        onPlayClick = {
+            viewModel.handleAction(HomeAction.ClickPlay)
+        },
     )
 
     if(isShownNoGatheringsPopup) {
@@ -245,9 +248,11 @@ private fun HomeScreen(
     statusBarHeight: Dp,
     userName: UiState<String>,
     loginState: LoginState,
+    selectedCurrentIndex: Int,
     gatherings: UiState<Gatherings>,
     proposalTags: UiState<ProposalTags>,
     homeBottomSheetAction: HomeBottomSheetAction,
+    isPlayed: Boolean,
     onWhenRefreshClick: () -> Unit,
     onWhereRefreshClick: () -> Unit,
     onWhatRefreshClick: () -> Unit,
@@ -257,21 +262,29 @@ private fun HomeScreen(
     onChangedState: (HomeBottomSheetState) -> Unit,
     onProposeClick: (Int) -> Unit,
     onProposalsClick: () -> Unit,
+    onStopClick: () -> Unit,
+    onPlayClick: () -> Unit,
     modifier: Modifier = Modifier,
     verticalScrollState : ScrollState = rememberScrollState()
 ) {
     val homeContentTopPadding = screenHeight / 2 - statusBarHeight -  TOP_APP_BAR_HEIGHT.dp
     val shake = remember { Animatable(0f) }
+    var isShook by rememberSaveable { mutableStateOf(false) }
 
-    LaunchedEffect(Unit) {
-        delay(200)
-        for (i in 0..10) {
-            when (i % 2) {
-                0 -> shake.animateTo(3f, spring(stiffness = 50_000f))
-                else -> shake.animateTo(-3f, spring(stiffness = 50_000f))
+
+    LaunchedEffect(isShook) {
+        if(!isShook) {
+            delay(1200)
+            for (i in 0..10) {
+                when (i % 2) {
+                    0 -> shake.animateTo(3f, spring(stiffness = 50_000f))
+                    else -> shake.animateTo(-3f, spring(stiffness = 50_000f))
+                }
             }
+            shake.animateTo(0f)
+            isShook = true
         }
-        shake.animateTo(0f)
+
     }
 
 
@@ -331,12 +344,16 @@ private fun HomeScreen(
                 whatLabels =  proposalTags.value.whatTags,
                 sheetPeekHeight = BOTTOM_SHEET_PEEK_HEIGHT.dp,
                 sheetFullHeight = BOTTOM_SHEET_FULL_HEIGHT.dp,
+                isPlayed = isPlayed,
+                selectedCurrentIndex = selectedCurrentIndex,
                 homeBottomSheetAction = homeBottomSheetAction,
                 onWhenRefreshClick = onWhenRefreshClick,
                 onWhereRefreshClick = onWhereRefreshClick,
                 onWhatRefreshClick = onWhatRefreshClick,
                 onChangedState = onChangedState,
-                onProposeClick = onProposeClick
+                onProposeClick = onProposeClick,
+                onStopClick = onStopClick,
+                onPlayClick = onPlayClick,
             )
         }
 
@@ -481,6 +498,7 @@ fun HomeScreenPreview(modifier: Modifier = Modifier) {
         loginState = LoginState.LoggedIn,
         gatherings = UiState.Success(Gatherings()),
         userName = UiState.Success(""),
+        isPlayed = false,
         onMyPageClick = {},
         onAddGatheringClick = {},
         onGatheringClick = {},
@@ -494,5 +512,8 @@ fun HomeScreenPreview(modifier: Modifier = Modifier) {
         onProposalsClick = {},
         screenHeight = 720.dp,
         statusBarHeight = 28.dp,
+        onStopClick = {},
+        onPlayClick = {},
+        selectedCurrentIndex = 0
     )
 }

--- a/feature/home/src/main/java/com/plottwist/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/plottwist/feature/home/HomeScreen.kt
@@ -178,6 +178,9 @@ fun HomeScreen(
         },
         onChangedState = {
             bottomSheetState = it
+            if(it == HomeBottomSheetState.COLLAPSED) {
+                viewModel.handleAction(HomeAction.ClickPlay)
+            }
         },
         onWhenRefreshClick = {
             viewModel.handleAction(HomeAction.ClickRefreshWhen)

--- a/feature/home/src/main/java/com/plottwist/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/plottwist/feature/home/HomeViewModel.kt
@@ -116,6 +116,13 @@ class HomeViewModel @Inject constructor(
             HomeAction.OnPermissionGranted -> {
                 handleOnPermissionGranted()
             }
+
+            HomeAction.ClickPlay -> {
+                handleRandomClick(isStop = false)
+            }
+            HomeAction.ClickStop -> {
+                handleRandomClick(isStop = true)
+            }
         }
     }
 
@@ -216,6 +223,7 @@ class HomeViewModel @Inject constructor(
                 val gatherings = state.gatherings as UiState.Success
                 val proposalTags = state.proposalTags as UiState.Success
                 if (gatherings.value.gatheringOverviews.isNotEmpty()) {
+                    reduce { state.copy(currentIndex = index) }
                     postSideEffect(
                         HomeSideEffect.NavigateToSelectGatheringScreen(
                             whereLabel = proposalTags.value.whereTags[index],
@@ -224,6 +232,7 @@ class HomeViewModel @Inject constructor(
                         )
                     )
                 } else {
+                    reduce { state.copy(currentIndex = index) }
                     postSideEffect(
                         HomeSideEffect.NavigateToCreateProposalScreen(
                             whereLabel = proposalTags.value.whereTags[index],
@@ -235,6 +244,7 @@ class HomeViewModel @Inject constructor(
             }
 
             else -> {
+                reduce { state.copy(currentIndex = index) }
                 postSideEffect(HomeSideEffect.NavigateToLoginScreen)
             }
         }
@@ -283,5 +293,13 @@ class HomeViewModel @Inject constructor(
 
     private fun handleOnPermissionGranted() = intent {
         updateDeviceTokenUseCase()
+    }
+
+    private fun handleRandomClick(isStop: Boolean) = intent {
+        reduce {
+            state.copy(
+                isRandomPlaying = !isStop
+            )
+        }
     }
 }

--- a/feature/home/src/main/java/com/plottwist/feature/home/component/HomeBottomSheet.kt
+++ b/feature/home/src/main/java/com/plottwist/feature/home/component/HomeBottomSheet.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -48,23 +49,28 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun HomeBottomSheet(
+    selectedCurrentIndex: Int,
     whenLabels: List<String>,
     whereLabels: List<String>,
     whatLabels: List<String>,
     sheetPeekHeight: Dp,
     sheetFullHeight: Dp,
     homeBottomSheetAction: HomeBottomSheetAction,
+    isPlayed: Boolean,
     onChangedState: (HomeBottomSheetState) -> Unit,
     onWhenRefreshClick: () -> Unit,
     onWhereRefreshClick: () -> Unit,
     onWhatRefreshClick: () -> Unit,
     onProposeClick: (Int) -> Unit,
+    onStopClick: () -> Unit,
+    onPlayClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-   var isPlayed by remember { mutableStateOf(true) }
+
 
     DraggableBottomSheet(
         modifier = modifier,
+        selectedCurrentIndex = selectedCurrentIndex,
         isPlayed = isPlayed,
         whenLabels = whenLabels,
         whereLabels = whereLabels,
@@ -77,8 +83,8 @@ fun HomeBottomSheet(
         sheetFullHeight = sheetFullHeight,
         onChangedState = onChangedState,
         onProposeClick = onProposeClick,
-        onStopClick = { isPlayed = !isPlayed },
-        onPlayClick = { isPlayed = !isPlayed }
+        onStopClick = onStopClick,
+        onPlayClick = onPlayClick,
     )
 }
 
@@ -86,6 +92,7 @@ fun HomeBottomSheet(
 fun DraggableBottomSheet(
     modifier: Modifier = Modifier,
     isPlayed: Boolean,
+    selectedCurrentIndex: Int,
     whenLabels: List<String>,
     whereLabels: List<String>,
     whatLabels: List<String>,
@@ -111,7 +118,14 @@ fun DraggableBottomSheet(
     val sheetFullPx = with(density) { sheetFullHeight.toPx() }
     val thresholdPx = with(density) { thresholdHeight.toPx() }
 
-    val offsetY = remember { Animatable(sheetFullPx - sheetPeekPx) }
+    val savedOffset = rememberSaveable { mutableStateOf(sheetFullPx - sheetPeekPx) }
+    val offsetY = remember {
+        Animatable(savedOffset.value)
+    }
+
+    LaunchedEffect(offsetY.value) {
+        savedOffset.value = offsetY.value
+    }
 
     var dragDelta by remember { mutableFloatStateOf(0f) }
     LaunchedEffect(Unit) {
@@ -263,6 +277,7 @@ fun DraggableBottomSheet(
                     RandomProposal(
                         modifier = Modifier.padding(top = 4.dp),
                         isPlayed = isPlayed,
+                        selectedCurrentIndex = selectedCurrentIndex,
                         whenLabels = whenLabels,
                         whereLabels = whereLabels,
                         whatLabels = whatLabels,
@@ -271,7 +286,7 @@ fun DraggableBottomSheet(
                         onWhatRefreshClick = onWhatRefreshClick,
                         onProposeClick = onProposeClick,
                         onStopClick = onStopClick,
-                        onPlayClick = onPlayClick
+                        onPlayClick = onPlayClick,
                     )
                 }
             }

--- a/feature/home/src/main/java/com/plottwist/feature/home/component/RandomProposal.kt
+++ b/feature/home/src/main/java/com/plottwist/feature/home/component/RandomProposal.kt
@@ -53,6 +53,7 @@ import kotlinx.coroutines.isActive
 @Composable
 fun RandomProposal(
     isPlayed: Boolean,
+    selectedCurrentIndex: Int,
     whenLabels: List<String>,
     whereLabels: List<String>,
     whatLabels: List<String>,
@@ -64,7 +65,7 @@ fun RandomProposal(
     onPlayClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    var currentIndex by remember { mutableIntStateOf(0) }
+    var currentIndex by remember { mutableIntStateOf(selectedCurrentIndex) }
 
     val lifecycleOwner = LocalLifecycleOwner.current
     val minSize = arrayOf(whatLabels.size, whereLabels.size, whenLabels.size).min()

--- a/feature/proposal-create/src/main/java/com/plottwist/feature/proposal_create/gathering_select/SelectGatheringScreen.kt
+++ b/feature/proposal-create/src/main/java/com/plottwist/feature/proposal_create/gathering_select/SelectGatheringScreen.kt
@@ -76,7 +76,6 @@ private fun SelectGatheringScreen(
                 modifier = Modifier.fillMaxWidth()
                     .padding(horizontal = 20.dp, vertical = 16.dp),
                 text = stringResource(R.string.create_proposal_propose),
-                buttonType = TukSolidButtonType.from(gatherings.any { it.selected }),
                 onClick = onProposalClick
             )
         }


### PR DESCRIPTION
## 작업
- 초대장 생성 시 모임 선택 화면에서 미선택이어도 다음하도록 처리
- 바텀 시트가 펼쳐져 있을 때 상태 유지하도록 처리


## 스크린샷 or 영상


https://github.com/user-attachments/assets/90977bd1-1b9b-429e-a62d-03da78a9a34b

