### PR TITLE
초대장 생성 후 홈으로 이동 시 바텀 시트 펼쳐져있는 이슈를 수정합니다.

### DIFF
--- a/feature/main/src/main/java/com/plottwist/feature/main/ui/component/TukNavHost.kt
+++ b/feature/main/src/main/java/com/plottwist/feature/main/ui/component/TukNavHost.kt
@@ -255,7 +255,8 @@ fun TukNavHost(
                         popUpTo(Route.Home) {
                             inclusive = true
                         }
-                        launchSingleTop = true
+                        launchSingleTop = false
+                        restoreState = false
                     }
                 )
             }

--- a/feature/proposal-create/src/main/java/com/plottwist/feature/proposal_create/complete/CompleteProposeScreen.kt
+++ b/feature/proposal-create/src/main/java/com/plottwist/feature/proposal_create/complete/CompleteProposeScreen.kt
@@ -2,6 +2,7 @@ package com.plottwist.feature.proposal_create.complete
 
 import android.content.Context
 import android.content.Intent
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -38,6 +39,10 @@ fun CompleteProposeScreen(
 ) {
     val state by viewModel.collectAsState()
     val context = LocalContext.current
+
+    BackHandler {
+        navigateToHome()
+    }
 
     viewModel.collectSideEffect {
         when (it) {


### PR DESCRIPTION
## 작업
- 초대장 생성 완료 화면에서 뒤로 가거나 X버튼 클릭하여 이동 시 홈 상태 유지하지 않게 수정


## 스크린샷 or 영상


https://github.com/user-attachments/assets/0d5b3425-2527-41ba-8320-adab299bf56c

