### PR TITLE
백그라운드에서 푸시 알림 클릭 시 딥링크 이동이 되지 않는 이슈를 수정합니다.

### DIFF
--- a/core/push/src/main/java/com/plottwist/core/push/TukFirebaseMessagingService.kt
+++ b/core/push/src/main/java/com/plottwist/core/push/TukFirebaseMessagingService.kt
@@ -2,6 +2,7 @@ package com.plottwist.core.push
 
 import android.app.PendingIntent
 import android.content.Intent
+import com.google.firebase.messaging.Constants
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.plottwist.core.notification.TukNotificationManager
@@ -15,20 +16,16 @@ class TukFirebaseMessagingService : FirebaseMessagingService() {
     @Inject
     lateinit var tukNotificationManager: TukNotificationManager
 
-
     override fun onNewToken(token: String) {
         super.onNewToken(token)
     }
 
     override fun onMessageReceived(message: RemoteMessage) {
         super.onMessageReceived(message)
-
-        message.notification?.let { notificationMessage ->
-            val title = notificationMessage.title ?: TukNotificationManager.DEFAULT_TITLE
-            val description = notificationMessage.body ?: TukNotificationManager.DEFAULT_DESCRIPTION
-            val deeplink = message.data.get("deepLink") ?: ""
-            sendNotification(title, description, deeplink)
-        }
+        val title = message.data.get("title") ?: ""
+        val description = message.data.get("body") ?: ""
+        val deeplink = message.data.get("deepLink") ?: ""
+        sendNotification(title, description, deeplink)
     }
 
     private fun sendNotification(title: String, description: String, deeplink: String) {
@@ -51,5 +48,18 @@ class TukFirebaseMessagingService : FirebaseMessagingService() {
                 description = description
             )
         )
+    }
+
+
+    override fun handleIntent(intent: Intent?) {
+        val newIntent = intent?.apply {
+            val newExtras = extras?.apply {
+                remove(Constants.MessageNotificationKeys.ENABLE_NOTIFICATION)
+                remove("gcm.notification.e")
+            }
+            replaceExtras(newExtras)
+        }
+        super.handleIntent(newIntent)
+
     }
 }


### PR DESCRIPTION
## 작업
- FirebaseMessagingService에서 푸시 수신 시 Notification 메세지로 인식되지 않게 관련 요소들을 제거
  - Data 메세지 값들을 통해 타이틀, 바디, 딥링크 처리하도록 수정


## 스크린샷 or 영상
- 포그라운드, 백그라운드, 앱 종료 상태에서 모두 테스트하였습니다.


https://github.com/user-attachments/assets/61575272-07e7-457d-aaeb-0bca9da209bb


